### PR TITLE
feat: dynamic configuration to set HTML minifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,49 @@ Caddyserver v2 plugin that implements minification on-the-fly for CSS, HTML, JSO
 
 Because this directive does not come standard with Caddy, you may use route to order it the way you want. For example:
 
+Minimum configuration:
 ```sh
 http://localhost:9200 {
 	route {
 		minifier
-		encode zstd gzip
+		reverse_proxy localhost:8097
+	}
+}
+```
+
+Partial configuration:
+```sh
+http://localhost:9200 {
+	route {
+		minifier {
+			html {
+				KeepDefaultAttrVals		true
+				KeepDocumentTags		true
+				KeepEndTags				true
+				KeepQuotes				true
+			}
+		}
+		reverse_proxy localhost:8097
+	}
+}
+```
+
+Full configuration:
+```sh
+http://localhost:9200 {
+	route {
+		minifier {
+			html {
+				KeepConditionalComments	true
+				KeepSpecialComments		true
+				KeepComments			true
+				KeepWhitespace			true
+				KeepDefaultAttrVals		true
+				KeepDocumentTags		true
+				KeepEndTags				true
+				KeepQuotes				true
+			}
+		}
 		reverse_proxy localhost:8097
 	}
 }
@@ -18,11 +56,12 @@ http://localhost:9200 {
 
 ## Todo
 
-- [ ] Filter supported `Content-Type`, proposal:
+- [ ] Support for another `Content-Type` (css, js, etc):
 
 ```sh
 minifier {
-    support "text/html" "image/svg+xml"
+    js
+	css
 }
 ```
 

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -1,17 +1,20 @@
 package minifier
 
 import (
+	"log"
+	"strconv"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	htmlminify "github.com/tdewolff/minify/v2/html"
 )
 
 var moduleName = "minifier"
 
 func init() {
 	caddy.RegisterModule(Middleware{})
-	// httpcaddyfile.RegisterDirective(moduleName, parseCaddyfile)
 	httpcaddyfile.RegisterHandlerDirective(moduleName, parseCaddyfile)
 }
 
@@ -21,14 +24,101 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	return m, err
 }
 
+func converterStrToBoolean(str string) bool {
+	boolValue, err := strconv.ParseBool(str)
+	if err != nil {
+		// print error info
+		log.Println("error on converterStrToBoolean: ", err)
+
+		return false
+	}
+
+	return boolValue
+}
+
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.
 func (m *Middleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	d.Next() // consume directive name
+	// default configuration
+	m.Html = htmlminify.Minifier{
+		KeepConditionalComments: false,
+		KeepSpecialComments:     false,
+		KeepComments:            false,
+		KeepWhitespace:          false,
+		KeepDefaultAttrVals:     false,
+		KeepDocumentTags:        false,
+		KeepEndTags:             false,
+		KeepQuotes:              false,
+	}
 
-	// require an argument
-	// if !d.NextArg() {
-	// 	return d.ArgErr()
-	// }
+	// TODO: improve mechanism to matching config with available minifier config
+	for d.Next() {
+		if d.NextArg() {
+			return d.ArgErr()
+		}
+
+		// block 0 to determine config for specific content type
+		for d.NextBlock(0) {
+			if d.NextArg() {
+				return d.ArgErr()
+			}
+
+			// check content type name
+			var configFor = d.Val()
+
+			// block 1 to set config detail for specific content type
+			for d.NextBlock(1) {
+				if configFor == "html" {
+					if d.Val() == "KeepComments" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepComments = converterStrToBoolean(d.Val())
+					}
+
+					if d.Val() == "KeepWhitespace" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepWhitespace = converterStrToBoolean(d.Val())
+					}
+
+					if d.Val() == "KeepDefaultAttrVals" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepDefaultAttrVals = converterStrToBoolean(d.Val())
+					}
+
+					if d.Val() == "KeepDocumentTags" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepDocumentTags = converterStrToBoolean(d.Val())
+					}
+
+					if d.Val() == "KeepEndTags" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepEndTags = converterStrToBoolean(d.Val())
+					}
+
+					if d.Val() == "KeepQuotes" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepQuotes = converterStrToBoolean(d.Val())
+					}
+
+					if d.Val() == "KeepConditionalComments" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepConditionalComments = converterStrToBoolean(d.Val())
+					}
+
+					if d.Val() == "KeepSpecialComments" {
+						// get value from config
+						d.NextArg()
+						m.Html.KeepSpecialComments = converterStrToBoolean(d.Val())
+					}
+				}
+			}
+		}
+	}
 
 	return nil
 }

--- a/example/Caddyfile
+++ b/example/Caddyfile
@@ -1,7 +1,18 @@
 http://localhost:9200 {
 	route {
 		encode zstd gzip
-		minifier
+		minifier {
+			html {
+				KeepConditionalComments	true
+				KeepSpecialComments		true
+				KeepComments			true
+				KeepWhitespace			true
+				KeepDefaultAttrVals		true
+				KeepDocumentTags		true
+				KeepEndTags				true
+				KeepQuotes				true
+			}
+		}
 		reverse_proxy localhost:8097
 	}
 }

--- a/middleware.go
+++ b/middleware.go
@@ -6,12 +6,18 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/tdewolff/minify/v2"
+
 	htmlminify "github.com/tdewolff/minify/v2/html"
-	svgminify "github.com/tdewolff/minify/v2/svg"
+	// cssminify "github.com/tdewolff/minify/v2/css"
+	// jsminify "github.com/tdewolff/minify/v2/js"
 )
 
 type Middleware struct {
 	minify *minify.M
+	// content type minifier configuration
+	Html htmlminify.Minifier
+	// js   *jsminify.Minifier
+	// css  *cssminify.Minifier
 }
 
 // CaddyModule returns the Caddy module information.
@@ -29,17 +35,8 @@ func (m *Middleware) Provision(ctx caddy.Context) error {
 	if m.minify == nil {
 		m.minify = minify.New()
 
-		// minifier config
-		m.minify.Add("text/html", &htmlminify.Minifier{
-			KeepWhitespace:      false,
-			KeepDefaultAttrVals: true,
-			KeepDocumentTags:    true,
-			KeepEndTags:         true,
-			KeepQuotes:          true,
-		})
-		m.minify.Add("image/svg+xml", &svgminify.Minifier{
-			KeepComments: false,
-		})
+		// set config minifier
+		m.minify.Add("text/html", &m.Html)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

create caddy configuration to enable dynamic HTML minifier, e.g:

```sh
http://localhost:9200 {
	route {
		encode zstd gzip
		minifier {
			html {
				KeepDefaultAttrVals true
				KeepDocumentTags true
				KeepEndTags true
				KeepQuotes true
			}
		}
		reverse_proxy localhost:8097
	}
}
```

Configuration will set false / disable by default.